### PR TITLE
Fix coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts(x)'],
+  collectCoverageFrom: ['src/**/*.ts(x)?', '!src/**/stories.tsx'],
   setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts']
 }


### PR DESCRIPTION
Esse PR corrige a cobertura dos testes. Da forma como estava o `jest.config.js`, somente os arquivos com extensão `.tsx` estavam sendo considerados, mas não aqueles com extensão `.ts`. Além disso, é necessáiro também remover os arquivos da cobertura do `storybook` (que serão incluídos mais adiante).