### PR TITLE
Render with theme helper

### DIFF
--- a/src/utils/tests/helpers.tsx
+++ b/src/utils/tests/helpers.tsx
@@ -1,0 +1,7 @@
+import { ThemeProvider } from 'styled-components'
+import { render, RenderResult } from '@testing-library/react'
+
+import theme from 'styles/theme'
+
+export const renderWithTheme = (children: React.ReactNode): RenderResult =>
+  render(<ThemeProvider theme={theme}>{children}</ThemeProvider>)


### PR DESCRIPTION
This PR adds a helper that we can use to wrap the components and render them on testing so that we can test their styles (provided by the theme provider).